### PR TITLE
Check EOF after fgetc() instead of relying on feof()

### DIFF
--- a/bb2ascii/main.c
+++ b/bb2ascii/main.c
@@ -16,9 +16,9 @@ char *find_token(uint16_t token)
 
 int decodebb(FILE *fin, FILE *fout)
 {
-	while (!feof(fin))
+	int b;
+	while ((b = fgetc(fin)) != EOF)
 	{
-		uint8_t b = fgetc(fin);
 		if (b == 0)
 		{
 			fprintf(fout, "\n");
@@ -47,6 +47,12 @@ int decodebb(FILE *fin, FILE *fout)
 		}
 
 		fprintf(stderr, "Unknown character: 0x%02X\b", b);
+	}
+
+	if (ferror(fin))
+	{
+		perror("Read error");
+		return -1;
 	}
 
 	return 0;


### PR DESCRIPTION
Not all implementations sets the eof flag before the EOF marker have been read, causing an invalid 0xFFFF token to be read. (Encountered on BTRFS, but presumably reading from PIPE: on AmigaOS will give you a similar problem.)
Checking EOF after fgetc() will also prevent a possible infinite loop on read error.
