### PR TITLE
Change bs to lf in "Unknown character" printout

### DIFF
--- a/bb2ascii/main.c
+++ b/bb2ascii/main.c
@@ -46,7 +46,7 @@ int decodebb(FILE *fin, FILE *fout)
 			continue;
 		}
 
-		fprintf(stderr, "Unknown character: 0x%02X\b", b);
+		fprintf(stderr, "Unknown character: 0x%02X\n", b);
 	}
 
 	if (ferror(fin))


### PR DESCRIPTION
I assume the \b was supposed to be a \n

I don't know if this has any relevance to bb2ascii but it seems like the bb2 editor will load and save all characters below 128 except for linefeed that is converted to 0 and tab that is just dropped.
All others are kept and exported as they are stored when saving as ascii.
